### PR TITLE
Add service-router config step

### DIFF
--- a/Dockerfile-consul
+++ b/Dockerfile-consul
@@ -1,6 +1,6 @@
 FROM consul:latest
 
-RUN wget https://releases.hashicorp.com/consul/1.6.0-beta2/consul_1.6.0-beta2_linux_amd64.zip -O /tmp/consul.zip
+RUN wget https://releases.hashicorp.com/consul/1.6.0/consul_1.6.0_linux_amd64.zip -O /tmp/consul.zip
 RUN unzip /tmp/consul.zip -d /tmp
 RUN mv /tmp/consul /usr/local/bin/consul
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Consul Service Mesh - Example using Service Splitting
+ Consul Service Mesh - Example using Service Splitting
 
 ## Canary Deployments
 A Canary deployment is a technique for deploying a new version of a service, while avoiding downtime. During a canary deployment you shift a small percentage of traffic to a new version of a service while monitoring its behavior. Initially you send the smallest amount of traffic possible to the new service while still generating meaningful performance data. As you gain confidence in the new version you slowly increase the proportion of traffic it handles. Eventually, the canary version handles 100% of all traffic, at which point the old version can be completely deprecated and then removed from the environment.
@@ -95,13 +95,15 @@ The next configuration entry you need to add is the Service Resolver, which allo
 
 Service Resolvers allow you to filter for subsets of services based on information in the service registration. In this example, we are going to define the subsets “v1” and “v2” for the API service, based on its registered metadata. API service version 1 in the demo is already registered with the tags `v1` and service metadata `version:1`. When you register version 2 you will give it the tag `v2` and the metadata `version:2`. The `name` field is set to the name of the service in the Consul service catalog.
 
+Setting a `default_subset` will resolve all traffic which does not specify a `subset` destination to this value instead of allocating it amongst all subsets.
+
 The service resolver is already in your demo environment at `l7_config/api_service_resolver.json` and it looks like this.
 
 ```json
 {
   "kind": "service-resolver",
   "name": "api",
-
+  "default_subset": "v1",
   "subsets": {
     "v1": {
       "filter": "Service.Meta.version == 1"

--- a/docker-compose-v2.yml
+++ b/docker-compose-v2.yml
@@ -11,7 +11,7 @@ services:
       vpcbr:
         ipv4_address: 10.5.0.5
   api_proxy_v2:
-    image: nicholasjackson/consul-envoy:v1.6.0-beta3-v0.10.0
+    image: nicholasjackson/consul-envoy:v1.6.0-v0.10.0
     environment:
       CONSUL_HTTP_ADDR: 10.5.0.2:8500
       CONSUL_GRPC_ADDR: 10.5.0.2:8502

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     ports:
       - 9090:9090
   web_envoy:
-    image: nicholasjackson/consul-envoy:v1.6.0-beta3-v0.10.0
+    image: nicholasjackson/consul-envoy:v1.6.0-v0.10.0
     environment:
       CONSUL_HTTP_ADDR: 10.5.0.2:8500
       CONSUL_GRPC_ADDR: 10.5.0.2:8502
@@ -49,7 +49,7 @@ services:
       vpcbr:
         ipv4_address: 10.5.0.4
   api_proxy_v1:
-    image: nicholasjackson/consul-envoy:v1.6.0-beta3-v0.10.0
+    image: nicholasjackson/consul-envoy:v1.6.0-v0.10.0
     environment:
       CONSUL_HTTP_ADDR: 10.5.0.2:8500
       CONSUL_GRPC_ADDR: 10.5.0.2:8502

--- a/l7_config/api_service_resolver.json
+++ b/l7_config/api_service_resolver.json
@@ -1,7 +1,7 @@
 {
   "kind": "service-resolver",
   "name": "api",
-
+  "default_subset": "v1",
   "subsets": {
     "v1": {
       "filter": "Service.Meta.version == 1"

--- a/l7_config/api_service_router.json
+++ b/l7_config/api_service_router.json
@@ -1,0 +1,17 @@
+{
+  "kind": "service-router",
+  "name": "api",
+  "routes": [
+    {
+      "match": {
+        "http": {
+          "path_prefix": "/v2"
+        }
+      },
+      "destination": {
+        "service": "api",
+        "service_subset": "v2"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Updates the Consul version and Docker images, and adds a `service-router` config step to test sending traffic directly to a specific subset.

This behavior is not currently working as expected in my testing...